### PR TITLE
Bump version of templates to 1.2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 					<dependency>
 						<groupId>com.ansys</groupId>
 						<artifactId>pyansys-swagger-codegen</artifactId>
-						<version>1.2.2-SNAPSHOT</version>
+						<version>1.2.3-SNAPSHOT</version>
 						<scope>compile</scope>
 					</dependency>
 				</dependencies>


### PR DESCRIPTION
Template 1.2.3 fixes issue with missing content type declaration, and issue with formatting in pyproject.toml

Relies on PR #18 in openapi-client-template