### PR TITLE
Add log4j mitigation to workflow definition

### DIFF
--- a/.github/workflows/generate_library.yml
+++ b/.github/workflows/generate_library.yml
@@ -28,6 +28,7 @@ jobs:
     - name: Build client library
       run: mvn -Dbuild-id=${{ github.run_number }} -s .m2/settings.xml compile
       env:
+        MAVEN_OPTS: "-Dlog4j2.formatMsgNoLookups=true"
         SERVER_USERNAME: ${{ secrets.REPO_USER }}
         SERVER_PASSWORD: ${{ secrets.REPO_TOKEN }}
         


### PR DESCRIPTION
Add JVM flag to disable lookups in log4j2, we may not be vulnerable, but better safe than sorry in the short-term.