### PR TITLE
Use organizational bot token to create PR

### DIFF
--- a/.github/workflows/generate_library.yml
+++ b/.github/workflows/generate_library.yml
@@ -32,6 +32,13 @@ jobs:
         MAVEN_OPTS: "-Dlog4j2.formatMsgNoLookups=true"
         SERVER_USERNAME: ${{ secrets.REPO_USER }}
         SERVER_PASSWORD: ${{ secrets.REPO_TOKEN }}
+    
+    - name: Get Bot Application Token
+      id: get_workflow_token
+      uses: peter-murray/workflow-application-token-action@v1
+      with:
+        application_id: ${{ secrets.BOT_APPLICATION_ID }}
+        application_private_key: ${{ secrets.BOT_APPLICATION_PRIVATE_KEY }}
         
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3
@@ -42,6 +49,7 @@ jobs:
         signoff: false
         branch: client-library-build
         delete-branch: true
+        token: ${{ steps.get_workflow_token.outputs.token }}
         title: 'Update client library'
         body: |
           Update library with new YAML interface definition


### PR DESCRIPTION
Closes #24 

This PR switches from GITHUB_TOKEN to the organizational bot credentials to create the client library PR.

This should allow the tests to run on the client library PR.