### PR TITLE
Bump template version to 1.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
           <dependency>
             <groupId>com.ansys</groupId>
             <artifactId>pyansys-swagger-codegen</artifactId>
-            <version>1.2.4-SNAPSHOT</version>
+            <version>1.3.0-SNAPSHOT</version>
             <scope>compile</scope>
           </dependency>
         </dependencies>


### PR DESCRIPTION
Closes #31 

Use a new version of the code generator template. Generates code with an explicit runtime dependency on `Model`, `Api`, and `ApiClient` interfaces defined in `openapi-common`.