### PR TITLE
Add description of package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
           <dependency>
             <groupId>com.ansys</groupId>
             <artifactId>pyansys-swagger-codegen</artifactId>
-            <version>1.3.0-SNAPSHOT</version>
+            <version>1.3.1-SNAPSHOT</version>
             <scope>compile</scope>
           </dependency>
         </dependencies>


### PR DESCRIPTION
Closes #36 

This PR adds a description to the pom.xml file. Currently this configuration option will be ignored until a new release of the openapi-client-template is released.

This PR also includes a bump to the template version that includes the description parameter.