### PR TITLE
Clear contents of library folder before regenerating

### DIFF
--- a/.github/workflows/generate_library.yml
+++ b/.github/workflows/generate_library.yml
@@ -36,7 +36,7 @@ jobs:
         cache: maven
     
     - name: Clean library folder
-      run: rm -rf grantami-bomanalytics-openapi
+      run: rm -rf ansys-grantami-bomanalytics-openapi
       
     - name: Build client library
       run: mvn -Dbuild-id=${{ github.run_number }} -s .m2/settings.xml compile


### PR DESCRIPTION
This PR clears the contents of the library output folder before generating a new version. This means that if a file is removed from the template it will also disappear from this repository.