### PR TITLE
Add release step to CI/CD

### DIFF
--- a/.github/workflows/build_and_test_library.yml
+++ b/.github/workflows/build_and_test_library.yml
@@ -123,7 +123,7 @@ jobs:
 
       - uses: actions/download-artifact@v2
         with:
-          name: ansys-grantami-bomanalytics-wheel
+          name: ansys-grantami-bomanalytics-openapi-wheel
 
       # note how we use the PyPI tokens
       - name: Upload to Azure PyPi (disabled)
@@ -132,7 +132,7 @@ jobs:
           # twine upload --skip-existing ./**/*.whl
         env:
           TWINE_USERNAME: __token__
-          TWINE_PASSWORD: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
 
       - name: Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
Closes #44 

Adds a release step to the CI/CD workflow. Release is only triggered on pushing a tag, which will create a github release and push the results to PyPI (once uncommented).