### PR TITLE
Remove --pre argument from pyproject.toml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
           <dependency>
             <groupId>com.ansys</groupId>
             <artifactId>pyansys-swagger-codegen</artifactId>
-            <version>1.3.3-SNAPSHOT</version>
+            <version>1.3.4-SNAPSHOT</version>
             <scope>compile</scope>
           </dependency>
         </dependencies>


### PR DESCRIPTION
Remove the --pre argument from pyproject.toml by bumping the template version