### PR TITLE
Add hyperlink to pyproject.toml description

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
           <dependency>
             <groupId>com.ansys</groupId>
             <artifactId>pyansys-swagger-codegen</artifactId>
-            <version>1.4.0</version>
+            <version>1.4.0-SNAPSHOT</version>
             <scope>compile</scope>
           </dependency>
         </dependencies>


### PR DESCRIPTION
This PR adds a hyperlink to the project description as it will appear on PyPI.

 The test PyPI server currently shows this:

![image](https://user-images.githubusercontent.com/6451062/154692695-aa3a9172-974a-4bb4-85c6-307415a103b8.png)

This fix will set `ansys-grantami-bomanalytics` as a link to the github page.

The issue with the text being displayed as raw markdown is fixed here: https://github.com/pyansys/openapi-client-template/pull/44