### PR TITLE
Maint: Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,14 +11,12 @@ updates:
       interval: "weekly"
     labels:
       - "maintenance"
-      -
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     labels:
       - "maintenance"
-      -
   - package-ecosystem: "pip" # See documentation for possible values
     directory: "/ansys-grantami-bomanalytics-openapi/" # Location of package manifests
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,19 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-
-updates:
+    labels:
+      - "maintenance"
+      -
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "maintenance"
+      -
   - package-ecosystem: "pip" # See documentation for possible values
     directory: "/ansys-grantami-bomanalytics-openapi/" # Location of package manifests
     schedule:
       interval: "weekly"
+    labels:
+      - "maintenance"


### PR DESCRIPTION
Update the dependabot config. The duplicated `updates` group is probably why mvn dependencies are not being updated. Adds the `github-actions` ecosystem.