### PR TITLE
Release to private PyPI only

### DIFF
--- a/.github/workflows/build_and_test_library.yml
+++ b/.github/workflows/build_and_test_library.yml
@@ -2,6 +2,14 @@ name: 'CI'
 # Update the paths once you have created a client library build
 on:
   workflow_dispatch:
+    inputs:
+      publish-to-private-pypi:
+        description: Whether to publish the build to the private PyPI
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+        default: 'false'
   push:
     tags:
       - "*"
@@ -84,6 +92,19 @@ jobs:
           name: ${{ env.LIBRARY_NAME }}-artifacts
           path: ${{ env.LIBRARY_NAME }}/dist/
           retention-days: 7
+
+  publish:
+    name: "Publish"
+    runs-on: ubuntu-latest
+    needs: [build-library]
+    if: (github.event_name == 'workflow_dispatch') && (github.ref == 'refs/heads/main') && (inputs.publish-to-private-pypi == 'true')
+    steps:
+      - name: "Release to private PyPI"
+        uses: ansys/actions/release-pypi-private@v8
+        with:
+          library-name: ${{ env.LIBRARY_NAME }}
+          twine-username: "__token__"
+          twine-token: ${{ secrets.PYANSYS_PYPI_PRIVATE_PAT }}
 
   release:
     name: "Release"


### PR DESCRIPTION
Add an option to the workflow-dispatch trigger to push to private PyPI only.