### PR TITLE
Generate build provenance attestation

### DIFF
--- a/.github/workflows/build_and_test_library.yml
+++ b/.github/workflows/build_and_test_library.yml
@@ -62,6 +62,10 @@ jobs:
     name: "Build library"
     runs-on: ubuntu-latest
     needs: tests
+    permissions:
+      id-token: write
+      attestations: write
+
     steps:
 
       - name: "Checkout the project"
@@ -85,6 +89,11 @@ jobs:
         working-directory: ${{ env.LIBRARY_NAME }}
         run: |
           python -m twine check dist/*
+
+      - name: Generate build provenance attestation
+        uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
+        with:
+          subject-path: ${{ env.LIBRARY_NAME }}/dist/
 
       - name: "Upload artifacts"
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Closes #208 

Use Github action to attest provenance of artifacts.